### PR TITLE
Change figure closure in Plot_Quality_Control

### DIFF
--- a/nltools/interfaces.py
+++ b/nltools/interfaces.py
@@ -146,7 +146,8 @@ class Plot_Quality_Control(BaseInterface):
 		for x in frame_outlier:
 		    ax[5].axvline(x, color='r', linestyle='--')
 		f.savefig(filename) 
-		f.close()
+		plt.close(f)
+		del f
 
 		self._plot = filename
 


### PR DESCRIPTION
There was a syntax error preventing the figure from being closed. Change this to look like how it's handled in PlotRealignmentParameters. 

Would also suggest keeping naming conventions consistent e.g

PlotRealignmentParameters -> Plot_Realignment_Parameters