### PR TITLE
updated requirements to deal with new version of matplotlib.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 	nibabel>=2.0.1
 	scikit-learn>=0.18.1
-	nilearn>=0.3
+	nilearn>=0.4
 	pandas>=0.20
 	numpy>=1.9
 	seaborn>=0.7.0
-	matplotlib==2.0.2
+	matplotlib>=2.1
 	scipy
 	six
 	pynv


### PR DESCRIPTION
Thanks to Gael Varoquax for fixing matplotlib plotting issue in nilearn 0.4. 