### PR TITLE
Fix the onset_to_dm naming issue and grand-grand-mean

### DIFF
--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -103,12 +103,19 @@ class Brain_Data(object):
         X: Pandas DataFrame Design Matrix for running univariate models
         mask: binary nifiti file to mask brain data
         output_file: Name to write out to nifti file
+        grand_grand_mean: an int or None. SPM and AFNI scale all voxels to have grand-grand-mean = 100,
+        such that intensity values at each voxel can be interpreted as something akin to
+        proportion/percent signal change relative to the global mean of the entire brain.
+        FSL sets grand-grand-mean = 10,000, to be able to represent data with lower-precision
+        values (ints) while not encountering data-precision loss.
+
+
         **kwargs: Additional keyword arguments to pass to the prediction
                 algorithm
 
     """
 
-    def __init__(self, data=None, Y=None, X=None, mask=None, output_file=None,
+    def __init__(self, data=None, Y=None, X=None, mask=None, output_file=None,grand_grand_mean=None,
                  **kwargs):
         if mask is not None:
             if not isinstance(mask, nib.Nifti1Image):
@@ -159,6 +166,9 @@ class Brain_Data(object):
                 self.data = self.data.squeeze()
         else:
             self.data = np.array([])
+
+        if grand_grand_mean is not None:
+            self.data = self.data / self.data.mean() * grand_grand_mean
 
         if Y is not None:
             if isinstance(Y, six.string_types):

--- a/nltools/file_reader.py
+++ b/nltools/file_reader.py
@@ -18,7 +18,7 @@ def onsets_to_dm(F, TR, runLength, header='infer', sort=False,
                 addIntercept=False, **kwargs):
     """Function to read in a 2 or 3 column onsets file, specified in seconds,
         organized as: 'Stimulus,Onset','Onset,Stimulus','Stimulus,Onset,
-        Duration', or 'Onset,Duration,Stimulus'.
+        Duration', or 'Stimulus,Duration,Onset'.
 
         Args:
             df (str or dataframe): path to file or pandas dataframe

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 	pandas>=0.20
 	numpy>=1.9
 	seaborn>=0.7.0
-	matplotlib==2.0.2
+	matplotlib>=2.0.2
 	scipy
 	six
 	pynv


### PR DESCRIPTION
An inconsistency between the description ('Onset, Duration, Stimulus') and the code (['Stim','Duration','Onset']) in file_reader.py.

The change in requirements.txt is to solve the installing problem in mac os 10.9. Ignore it if it's not neccessary.

Also, changes for adding grand-grand-mean in Brain_Data.