### PR TITLE
update example to fix broken call to threshold()

### DIFF
--- a/examples/01_DataOperations/plot_mask.py
+++ b/examples/01_DataOperations/plot_mask.py
@@ -79,17 +79,17 @@ mask_c.plot()
 import numpy as np
 
 high = data[np.where(data.X['PainLevel']==3)[0]]
-high.mean().threshold(threshold='95%').plot()
+high.mean().threshold(lower='2.5%', upper='97.5%').plot()
 
 #########################################################################
 # We might be interested in creating a binary mask from this threshold.
 
-mask = high.mean().threshold(threshold='95%',binarize=True)
-mask.plot()
+mask_b = high.mean().threshold(lower='2.5%', upper='97.5%',binarize=True)
+mask_b.plot()
 
 #########################################################################
 # We might also want to create separate images from each contiguous ROI.
 
-region = high.mean().threshold(threshold='95%').regions()
+region = high.mean().threshold(lower='2.5%', upper='97.5%').regions()
 region.plot()
 


### PR DESCRIPTION
fill calls to threshold() to reflect new argument names

I also changed a variable name mask_b to prevent overwriting of examples main mask

Heads Up: in the current example, I expected the plot for
`threshold(lower='2.5%', upper='97.5%')`
to reproduce the original plot from
`threshold(threshold='95%')`
but the call that reproduces the original plot is the wrong-looking
`threshold(upper='95%')`

... or let me know if I'm on the wrong branch ...